### PR TITLE
fix(android): setup JNI support for non-rust Android apps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "animo-secure-env"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "jni",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "animo-secure-env"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.67"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 ## Supported targets
 
-- `aarch64-apple-ios`
-- `aarch64-apple-ios-sim`
-- `x86_64-apple-ios`
-- `aarch64-linux-android`
-- `armv7-linux-androideabi`
-- `i686-linux-android`
-- `x86_64-linux-android`
+-   `aarch64-apple-ios`
+-   `aarch64-apple-ios-sim`
+-   `x86_64-apple-ios`
+-   `aarch64-linux-android`
+-   `armv7-linux-androideabi`
+-   `i686-linux-android`
+-   `x86_64-linux-android`
 
 ## iOS
 
@@ -23,6 +23,26 @@ Android bindings are done via [jni-rs](https://github.com/jni-rs/jni-rs). It was
 Beneath these bindings it fully relies on `KeyStore`. During key generation, based on the support version, `setIsStrongBoxBacked` is set to make sure the key is store in hardware. If this is not supported we fall back to a lower level of security `setUserPresenceRequired`.
 
 > NOTE: there still needs to be some additional research done into the exact garantuees that `setUserPresenceRequired` provides. If it means TEE, it is all good.
+
+### Additional setup
+
+Due to time constraints, currently some additional setup is required for Android to fully work. This has to do with accessing the JVM pointer from Rust. If something like [android_activity](https://github.com/rust-mobile/android-activity) is used, take a look at the [android example](./examples/android/src/lib.rs). If this library is used from a React Native context, or native Android app, include the following in your project:
+
+```java
+package id.animo;
+
+public class SecureEnvironment {
+    static {
+        System.loadLibrary("secure_env");
+    }
+
+
+    public static native void set_env();
+}
+
+```
+
+Afterwards, you can call `SecureEnvironment.set_env` before making any calls to the library. Afterwards everything should be set up properly.
 
 ## Features
 

--- a/examples/android/Cargo.lock
+++ b/examples/android/Cargo.lock
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "animo-secure-env"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "jni",
  "lazy_static",
@@ -800,9 +800,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "memchr"

--- a/examples/android/src/lib.rs
+++ b/examples/android/src/lib.rs
@@ -1,7 +1,21 @@
 use android_activity::AndroidApp;
 use mobile_tests::run_tests;
 
+use jni::{JavaVM, JNIEnv, objects::JClass, sys::jobject};
+
+extern "system" {
+    fn Java_id_animo_SecureEnvironment_set_1env<'local>(env: JNIEnv<'local>, _class: JClass<'local>);
+}
+
 #[no_mangle]
-fn android_main(_app: AndroidApp) {
+fn android_main(app: AndroidApp) {
+    // Since we cannot use the jvm pointer set by `android_activity` we manually call the exposed
+    // method with a null pointer for a class (as it is not used anyways) and the jni env we
+    // receive from the `app`.
+    let jvm = unsafe { JavaVM::from_raw(app.vm_as_ptr() as *mut _) }.unwrap();
+    let env = unsafe { JNIEnv::from_raw(jvm.attach_current_thread().unwrap().get_raw()) }.unwrap();
+    let clazz = unsafe { JClass::from_raw(std::ptr::null::<jobject>() as *mut _) };
+    unsafe { Java_id_animo_SecureEnvironment_set_1env(env, clazz) };
+
     run_tests();
 }

--- a/src/jni_tokens.rs
+++ b/src/jni_tokens.rs
@@ -125,3 +125,11 @@ pub static SIGNATURE_UPDATE_SIG: &str = "([B)V";
 
 pub static SIGNATURE_SIGN: &str = "sign";
 pub static SIGNATURE_SIGN_SIG: &str = "()[B";
+
+pub static ACTIVITY_THREAD_CLS: &str = "android/app/ActivityThread";
+
+pub static ACTIVITY_THREAD_GET_CURRENT_ACTIVITY_THREAD: &str = "currentActivityThread";
+pub static ACTIVITY_THREAD_GET_CURRENT_ACTIVITY_THREAD_SIG: &str = "()Landroid/app/ActivityThread;";
+
+pub static ACTIVITY_THREAD_GET_APPLICATION: &str = "getApplication";
+pub static ACTIVITY_THREAD_GET_APPLICATION_SIG: &str = "()Landroid/app/Application;";


### PR DESCRIPTION
Short ramble time.


When testing the library within React Native I noticed that the `JAVA_VM` was not set, this is due to the fact the example app in this repository uses `android_activity` which sets this variable inside another library... This took some time to find :)

After I found that out, I had to set the `JAVA_VM` pointer myself, I have tried `JNI_OnLoad` and `ANativeActivity_onCreate` and both were not triggered (even though this library and AriesAskar had the public symbol in their library...).

Currently this is the best solution I could come up with. It does mean that the user, for Android, needs to create a java file, as described in the README, which is a bit annoying. Would like to revisit this in the future, but for now it unblocks progress for the ARF and Askar at least.